### PR TITLE
Fixes 404 when getting postalcodes

### DIFF
--- a/src/clj_suomi/codesets/postalcodes.clj
+++ b/src/clj_suomi/codesets/postalcodes.clj
@@ -9,7 +9,7 @@
   (:import [java.time LocalDate]
            [java.time.format DateTimeFormatter]))
 
-(def base-url "https://www.posti.fi/webpcode/")
+(def base-url "https://www.posti.fi/webpcode")
 
 (defn posti-url [filename]
   (str base-url filename))


### PR DESCRIPTION
Posti web server does not resolve file correctly if there is doubleslash on file url, ie: https://www.posti.fi/webpcode//PCF_20240712.zip